### PR TITLE
Fix compilation error introduced on previous merge

### DIFF
--- a/yafolding.el
+++ b/yafolding.el
@@ -145,7 +145,7 @@ If given, toggle all entries that start at INDENT-LEVEL."
   "Show yafolding information of the current position."
   (interactive)
   (message "indentation: %d, indent level: %d, ingore current line: %s, element-region: %d - %d, (L%d - L%d)"
-           (yafolding--current-indentation)
+           (current-indentation)
            (yafolding-get-indent-level)
            (yafolding-should-ignore-current-line-p)
            (car (yafolding-get-element-region))


### PR DESCRIPTION
Fix the following compilation error introduced on SHA:24d792053a0d4099e4ebec5a4f015b0c2a1cbf29

```
yafolding.el:148:13: Warning: the function ‘yafolding--current-indentation’ is
    not known to be defined.
```
