### PR TITLE
Remove the defunct yafolding--current-indentation call

### DIFF
--- a/yafolding.el
+++ b/yafolding.el
@@ -145,7 +145,7 @@ If given, toggle all entries that start at INDENT-LEVEL."
   "Show yafolding information of the current position."
   (interactive)
   (message "indentation: %d, indent level: %d, ingore current line: %s, element-region: %d - %d, (L%d - L%d)"
-           (yafolding--current-indentation)
+           (current-indentation)
            (yafolding-get-indent-level)
            (yafolding-should-ignore-current-line-p)
            (car (yafolding-get-element-region))

--- a/yafolding.el
+++ b/yafolding.el
@@ -25,14 +25,14 @@
 ;;; Code:
 
 (defgroup yafolding nil
-  "Fold code blocks based on indentation level"
+  "Fold code blocks based on indentation level."
   :prefix "yafolding-"
   :link '(url-link :tag "yafolding on github" "https://github.com/zenozeng/yafolding.el")
   :group 'applications)
 
 (defface yafolding-ellipsis-face
   '()
-  "Face for folded blocks"
+  "Face for folded blocks."
   :group 'yafolding)
 
 (defcustom yafolding-ellipsis-content "..."


### PR DESCRIPTION
Emacs 30 warns me with a compilation error:

```
⛔ Warning (native-compiler): ~/.emacs.d/elpa/yafolding-20200119.1353/yafolding.el:150:13: Warning: the function ‘yafolding--current-indentation’ is not known to be defined.
```
